### PR TITLE
Fixes for cddl syntax on teep-protocol

### DIFF
--- a/draft-ietf-suit-report.cddl
+++ b/draft-ietf-suit-report.cddl
@@ -8,20 +8,42 @@ SUIT_Report = {
   }
   $$SUIT_Report_Extensions
 }
+
 SUIT_Reference = {
     suit-report-manifest-uri  => tstr,
     suit-report-manifest-digest => SUIT_Digest,
 }
+
 SUIT_Record = [
     suit-record-manifest-id        : [* uint ],
     suit-record-manifest-section   : int,
     suit-record-section-offset     : uint,
     suit-record-component-index    : uint,
-    suit-record-properties         : SUIT_Parameters,
+    suit-record-properties         : {*$$SUIT_Parameters},
     $$SUIT_Record_Extensions
 ]
 
 system-property-claims = {
   system-component-id => SUIT_Component_Identifier,
-  + SUIT_Parameters,
+  + $$SUIT_Parameters,
 }
+
+suit-report-manifest-digest = 0
+suit-report-manifest-uri = 1
+suit-report-nonce = 2
+suit-report-records = 3
+suit-report-result = 4
+suit-report-result-code = 5
+suit-report-result-record = 6
+
+suit-reference = 99
+
+suit-system-properties = 13
+system-component-id = 0
+
+suit-record-manifest-id = 0
+suit-record-manifest-section = 1
+suit-record-section-offset = 2
+suit-record-component-index = 3
+suit-record-dependency-index = 4
+suit-record-properties = 5


### PR DESCRIPTION
Adding value to suit-reference.
Using map for SUIT_Parameters which is defined in suit manifest cddl file