### PR TITLE
May have no SUIT_Parameters in system-property-claims

### DIFF
--- a/draft-ietf-suit-report.cddl
+++ b/draft-ietf-suit-report.cddl
@@ -25,7 +25,7 @@ SUIT_Record = [
 
 system-property-claims = {
   system-component-id => SUIT_Component_Identifier,
-  + $$SUIT_Parameters,
+  * $$SUIT_Parameters,
 }
 
 suit-report-manifest-digest = 0

--- a/draft-ietf-suit-report.md
+++ b/draft-ietf-suit-report.md
@@ -220,7 +220,7 @@ SUIT_Report = {
 }
 system-property-claims = {
   system-component-id => SUIT_Component_Identifier,
-  + SUIT_Parameters,
+  * $$SUIT_Parameters,
 }
 ~~~
 


### PR DESCRIPTION
This PR will allow the system-property-claims in SUIT_Report for the TEEP Protocol to have no SUIT_Parameters.

It is discussed at the issue in TEEP Protocol.
https://github.com/ietf-teep/teep-protocol/issues/291

